### PR TITLE
Redesign QA portfolio homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,31 +3,36 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#0b0f14" />
 
-  <title>Polina | QA Engineer</title>
+  <title>Polina Ponezha | QA Engineer</title>
   <meta
     name="description"
-    content="QA Engineer focused on Web, Mobile, API Testing, API Automation and AI-assisted QA workflows."
+    content="QA Engineer focused on web, mobile, API testing, API automation and AI-assisted QA workflows."
   />
+  <meta property="og:title" content="Polina Ponezha | QA Engineer" />
+  <meta property="og:description" content="Web, mobile and API QA with API automation growth." />
+  <meta property="og:type" content="website" />
 
-  <link rel="stylesheet" href="./styles.css?v=4" />
+  <link rel="stylesheet" href="./styles.css?v=7" />
+  <script src="./script.js?v=1" defer></script>
 </head>
 
 <body>
-  <div class="noise"></div>
-  <div class="orb orb-1"></div>
-  <div class="orb orb-2"></div>
-  <div class="orb orb-3"></div>
-
   <header class="header">
     <div class="container header-inner">
-      <a href="#top" class="logo">
-        <span class="logo-mark">P</span>
-        <span>Polina</span>
+      <a href="#top" class="brand" aria-label="Polina Ponezha home">
+        <span class="brand-mark">P</span>
+        <span>Polina Ponezha</span>
       </a>
 
-      <nav class="nav">
-        <a href="#focus">Focus</a>
+      <button class="nav-toggle" type="button" aria-label="Open navigation" aria-expanded="false">
+        <span></span>
+        <span></span>
+      </button>
+
+      <nav class="nav" aria-label="Main navigation">
+        <a href="#profile">Profile</a>
         <a href="#skills">Skills</a>
         <a href="#experience">Experience</a>
         <a href="#projects">Projects</a>
@@ -39,63 +44,48 @@
   <main id="top">
     <section class="hero">
       <div class="container hero-grid">
-        <div class="hero-content">
-          <span class="eyebrow">QA Engineer · Web · Mobile · API</span>
-
-              <h1>
-            Product QA with
-          <span>API, automation & AI-assisted workflows.</span>
-              </h1>
-
-          <p class="hero-description">
-            QA Engineer with commercial experience in web, mobile and API testing.
-            I review requirements, validate Swagger/API contracts, investigate defects
-            and contribute to API automation using Java, TestNG, Maven, RestAssured
-            and Allure Reports.
+        <div class="hero-copy" data-animate>
+          <p class="eyebrow">QA Engineer · Portugal · Open to opportunities</p>
+          <h1>QA Engineer for web, mobile & API products.</h1>
+          <p class="hero-text">
+            I test product behavior, validate API contracts and grow into automation with
+            Java, TestNG, Maven, RestAssured and Allure.
           </p>
 
-          <div class="hero-actions">
-            <a class="btn btn-primary" href="https://www.linkedin.com/in/polinapoo/" target="_blank" rel="noreferrer">
-              View LinkedIn
-            </a>
-            <a class="btn btn-secondary" href="https://github.com/pikuso" target="_blank" rel="noreferrer">
-              View GitHub
-            </a>
+          <div class="hero-actions" aria-label="Primary links">
+            <a class="button primary" href="https://www.linkedin.com/in/polinapoo/" target="_blank" rel="noreferrer">LinkedIn</a>
+            <a class="button secondary" href="https://github.com/pikuso" target="_blank" rel="noreferrer">GitHub</a>
+            <a class="button ghost" href="#contact">Contact</a>
           </div>
 
-          <div class="quick-stack">
-            <span>Manual QA</span>
+          <div class="hero-tags" aria-label="Core profile tags">
             <span>API Testing</span>
+            <span>Web & Mobile QA</span>
             <span>API Automation</span>
             <span>AI-assisted QA</span>
           </div>
         </div>
 
-        <aside class="hero-card">
-          <div class="hero-card-top">
-            <img src="avatar.jpg" alt="Polina profile photo" />
-
-            <div class="status-card">
-              <span class="status-dot"></span>
-              Open to QA opportunities
-            </div>
+        <aside class="profile-card" data-animate>
+          <div class="photo-wrap">
+            <img src="avatar.jpg" alt="Polina Ponezha profile photo" />
+            <span class="availability">Available for QA roles</span>
           </div>
 
-          <div class="hero-card-body">
-            <p class="card-label">Current positioning</p>
-            <h2>Manual QA with API automation growth</h2>
-
-            <div class="stats-grid">
+          <div class="profile-card-body">
+            <p class="card-kicker">Current direction</p>
+            <h2>QA with strong API focus and automation growth.</h2>
+            <div class="mini-stats">
               <div>
                 <strong>200+</strong>
-                <span>test cases created</span>
+                <span>test cases & checklists</span>
               </div>
               <div>
                 <strong>Web · iOS · Android</strong>
                 <span>platform coverage</span>
               </div>
               <div>
-                <strong>Java · TestNG · Allure</strong>
+                <strong>Java · TestNG · RestAssured</strong>
                 <span>automation stack</span>
               </div>
             </div>
@@ -104,91 +94,56 @@
       </div>
     </section>
 
-    <section class="section" id="focus">
-      <div class="container">
-        <div class="section-title">
-          <span class="eyebrow">Focus</span>
-          <h2>What I can bring to a QA team</h2>
+    <section class="section compact-section" id="profile">
+      <div class="container split-layout">
+        <div class="section-copy" data-animate>
+          <p class="eyebrow">Profile</p>
+          <h2>Practical QA. Clear reports. Less guessing.</h2>
+          <p>
+            I work with requirements, Jira tasks, Swagger documentation and Figma designs
+            to catch gaps before they become bugs. My strongest direction is API quality:
+            contracts, auth behavior, error responses, schemas and edge cases.
+          </p>
         </div>
 
-        <div class="focus-grid">
-          <article class="focus-card large requirement-card">
-    <div class="requirement-visual">
-      <div class="visual-line"></div>
-      <div class="visual-row">
-        <span>Requirements</span>
-        <strong>Review</strong>
-      </div>
-      <div class="visual-row">
-        <span>Swagger</span>
-        <strong>API contract</strong>
-      </div>
-      <div class="visual-row">
-        <span>Edge cases</span>
-        <strong>Coverage</strong>
-      </div>
-      <div class="visual-row">
-        <span>Risks</span>
-        <strong>Prevention</strong>
-      </div>
-    </div>
-  
-    <div>
-      <span class="card-number">01</span>
-      <h3>Requirement-driven testing</h3>
-      <p>
-        I analyze requirements, Jira tasks, Swagger documentation and Figma designs
-        to find unclear behavior, missing edge cases and potential test gaps early.
-      </p>
-    </div>
-  </article>
-
-          <article class="focus-card">
-            <span class="card-number">02</span>
-            <h3>API validation</h3>
-            <p>
-              I validate REST API behavior, status codes, authentication, headers,
-              error responses, JSON structure and schema consistency.
-            </p>
-          </article>
-
-          <article class="focus-card">
-            <span class="card-number">03</span>
-            <h3>Automation mindset</h3>
-            <p>
-              I contribute to API automation with Java, TestNG, Maven, RestAssured
-              and Allure Reports.
-            </p>
-          </article>
-
-          <article class="focus-card wide">
-            <span class="card-number">04</span>
-            <h3>AI-assisted QA workflow</h3>
-            <p>
-              I use AI tools to speed up checklist drafting, test ideas, bug report wording,
-              edge-case generation and automation scenario preparation — while keeping final
-              QA validation human.
-            </p>
-          </article>
+        <div class="focus-chart" data-animate aria-label="Current QA focus areas">
+          <div class="chart-header">
+            <span>Current focus mix</span>
+            <strong>2026</strong>
+          </div>
+          <div class="bar-row" style="--scale: .36">
+            <span>API testing</span>
+            <div class="bar"><span></span></div>
+            <strong>36%</strong>
+          </div>
+          <div class="bar-row" style="--scale: .26">
+            <span>Web / mobile QA</span>
+            <div class="bar"><span></span></div>
+            <strong>26%</strong>
+          </div>
+          <div class="bar-row" style="--scale: .24">
+            <span>API automation</span>
+            <div class="bar"><span></span></div>
+            <strong>24%</strong>
+          </div>
+          <div class="bar-row" style="--scale: .14">
+            <span>AI-assisted workflow</span>
+            <div class="bar"><span></span></div>
+            <strong>14%</strong>
+          </div>
         </div>
       </div>
     </section>
 
     <section class="section" id="skills">
       <div class="container">
-        <div class="section-title row-title">
-          <div>
-            <span class="eyebrow">Skills</span>
-            <h2>QA toolbox</h2>
-          </div>
-          <p>
-            A practical stack for manual testing, API validation, documentation
-            and automation growth.
-          </p>
+        <div class="section-head" data-animate>
+          <p class="eyebrow">Skills</p>
+          <h2>QA toolbox</h2>
         </div>
 
-        <div class="skills-layout">
-          <article class="skill-card">
+        <div class="skills-grid">
+          <article class="skill-card" data-animate>
             <h3>Core QA</h3>
             <div class="chips">
               <span>Functional Testing</span>
@@ -198,12 +153,12 @@
               <span>Negative Testing</span>
               <span>UI Testing</span>
               <span>Responsive Testing</span>
-              <span>Cross-Browser Testing</span>
+              <span>Cross-browser Testing</span>
               <span>Basic Accessibility Checks</span>
             </div>
           </article>
 
-          <article class="skill-card highlight">
+          <article class="skill-card accent" data-animate>
             <h3>API Testing</h3>
             <div class="chips">
               <span>REST API</span>
@@ -219,7 +174,7 @@
             </div>
           </article>
 
-          <article class="skill-card">
+          <article class="skill-card" data-animate>
             <h3>Automation</h3>
             <div class="chips">
               <span>Java</span>
@@ -234,7 +189,7 @@
             </div>
           </article>
 
-          <article class="skill-card">
+          <article class="skill-card" data-animate>
             <h3>Web & Mobile</h3>
             <div class="chips">
               <span>Web Testing</span>
@@ -250,7 +205,7 @@
             </div>
           </article>
 
-          <article class="skill-card wide-skill">
+          <article class="skill-card wide" data-animate>
             <h3>Documentation & AI-assisted QA</h3>
             <div class="chips">
               <span>Requirement Review</span>
@@ -265,7 +220,7 @@
               <span>AI-assisted Test Ideas</span>
               <span>Checklist Drafting</span>
               <span>Bug Report Polishing</span>
-              <span>Playwright Scenario Drafting</span>
+              <span>Automation Scenario Drafting</span>
             </div>
           </article>
         </div>
@@ -273,65 +228,54 @@
     </section>
 
     <section class="section" id="experience">
-      <div class="container experience-grid">
-        <div>
-          <div class="section-title">
-            <span class="eyebrow">Experience</span>
-            <h2>Commercial QA experience</h2>
-          </div>
-
-          <div class="timeline">
-            <article class="timeline-card">
-              <div class="timeline-meta">
-                <span>Jun 2025 — Present</span>
-                <span>Junior QA Engineer</span>
-              </div>
-
-              <h3>NDA Product Company</h3>
-              <p class="role">Social Networking Platform</p>
-
-              <ul>
-                <li>Reviewed requirements, Jira tasks, Swagger documentation and Figma designs to identify unclear behavior, missing edge cases and test gaps.</li>
-                <li>Tested web and mobile features across iOS, Android and major desktop browsers.</li>
-                <li>Performed functional, smoke, regression, exploratory, negative, UI, API, cross-browser, responsive and basic accessibility testing.</li>
-                <li>Created and maintained 200+ test cases and checklists in Zephyr, Jira and Google Sheets.</li>
-                <li>Validated REST API behavior using Postman and Swagger, including status codes, auth behavior, headers, request/response structure, error codes and JSON schema consistency.</li>
-                <li>Contributed to API test automation using Java, TestNG, Maven, RestAssured and Allure Reports.</li>
-                <li>Investigated issues using Chrome DevTools, BrowserStack, TestFlight and Charles Proxy.</li>
-              </ul>
-            </article>
-
-            <article class="timeline-card compact">
-              <div class="timeline-meta">
-                <span>Oct 2024 — May 2025</span>
-                <span>QA Trainee</span>
-              </div>
-
-              <h3>QA Mentorship Program</h3>
-              <p class="role">Practical QA Training</p>
-
-              <ul>
-                <li>Practiced test design, bug reporting, smoke/regression testing, API checks and SQL basics.</li>
-              </ul>
-            </article>
-          </div>
+      <div class="container experience-layout">
+        <div data-animate>
+          <p class="eyebrow">Experience</p>
+          <h2>Commercial QA experience</h2>
         </div>
 
-        <aside class="side-panel">
-          <article class="side-card">
-            <h3>Education</h3>
-            <p class="side-date">Sep 2022 — Jun 2026</p>
-            <p class="side-title">Professional Junior Bachelor, Software Engineering</p>
-            <p>College of Economics, Law and Information Technologies “KROK”</p>
+        <div class="timeline">
+          <article class="timeline-card" data-animate>
+            <div class="timeline-top">
+              <span>Jun 2025 — Present</span>
+              <span>Junior QA Engineer</span>
+            </div>
+            <h3>NDA Product Company</h3>
+            <p class="role">Social networking platform</p>
+            <ul>
+              <li>Review requirements, Jira tasks, Swagger documentation and Figma designs to find unclear behavior and test gaps early.</li>
+              <li>Test web and mobile features across iOS, Android and desktop browsers.</li>
+              <li>Perform functional, smoke, regression, exploratory, negative, UI, API, responsive and basic accessibility testing.</li>
+              <li>Create and maintain 200+ test cases and checklists in Zephyr, Jira and Google Sheets.</li>
+              <li>Validate REST API behavior: status codes, auth, headers, request/response structure, error codes and schema consistency.</li>
+              <li>Contribute to API automation with Java, TestNG, Maven, RestAssured and Allure Reports; review code in GitLab.</li>
+              <li>Investigate issues using Chrome DevTools, BrowserStack, TestFlight and Charles Proxy.</li>
+            </ul>
           </article>
 
-          <article class="side-card">
+          <article class="timeline-card compact" data-animate>
+            <div class="timeline-top">
+              <span>Oct 2024 — May 2025</span>
+              <span>QA Trainee</span>
+            </div>
+            <h3>QA Mentorship Program</h3>
+            <p>Practiced test design, bug reporting, smoke/regression testing, API checks and SQL basics.</p>
+          </article>
+        </div>
+
+        <aside class="info-stack" data-animate>
+          <article>
+            <h3>Education</h3>
+            <p class="muted">Sep 2022 — Jun 2026</p>
+            <p>Professional Junior Bachelor, Software Engineering</p>
+            <p>College of Economics, Law and Information Technologies “KROK”</p>
+          </article>
+          <article>
             <h3>Training</h3>
             <p>EPAM Pre-Junior Program</p>
             <p>EPAM IT Fundamentals</p>
           </article>
-
-          <article class="side-card">
+          <article>
             <h3>Languages</h3>
             <p>Ukrainian — Native</p>
             <p>Russian — Fluent</p>
@@ -343,25 +287,17 @@
 
     <section class="section" id="projects">
       <div class="container">
-        <div class="section-title">
-          <span class="eyebrow">Projects</span>
-          <h2>Relevant QA projects</h2>
+        <div class="section-head" data-animate>
+          <p class="eyebrow">Projects</p>
+          <h2>Selected QA work</h2>
         </div>
 
         <div class="projects-grid">
-          <article class="project-card">
-            <div class="project-top">
-              <span>Automation</span>
-              <strong>01</strong>
-            </div>
-
+          <article class="project-card" data-animate>
+            <span class="project-type">Automation</span>
             <h3>ParaBank Test Automation</h3>
-            <p>
-              UI automation project for a banking demo application. Covered login,
-              account opening and money transfer flows using Page Object Model.
-            </p>
-
-            <div class="project-stack">
+            <p>UI automation project for a banking demo app: login, account opening and money transfer flows using Page Object Model.</p>
+            <div class="chips compact-chips">
               <span>Java</span>
               <span>Selenium</span>
               <span>Maven</span>
@@ -371,19 +307,11 @@
             </div>
           </article>
 
-          <article class="project-card accent-card">
-            <div class="project-top">
-              <span>API QA</span>
-              <strong>02</strong>
-            </div>
-
+          <article class="project-card featured" data-animate>
+            <span class="project-type">API QA</span>
             <h3>API Testing & Automation</h3>
-            <p>
-              REST API validation and automation contribution focused on Swagger contracts,
-              auth behavior, error responses, schema consistency and report generation.
-            </p>
-
-            <div class="project-stack">
+            <p>REST API validation and automation contribution focused on Swagger contracts, auth behavior, error responses and report generation.</p>
+            <div class="chips compact-chips">
               <span>Java</span>
               <span>TestNG</span>
               <span>Maven</span>
@@ -393,25 +321,31 @@
             </div>
           </article>
 
-          <article class="project-card">
-            <div class="project-top">
-              <span>AI-assisted QA</span>
-              <strong>03</strong>
-            </div>
-
-            <h3>AI-supported QA Workflow</h3>
-            <p>
-              Exploration of AI-supported QA workflows: checklist generation,
-              edge-case expansion, bug report polishing and automation scenario drafting.
-            </p>
-
-            <div class="project-stack">
+          <article class="project-card" data-animate>
+            <span class="project-type">AI-assisted QA</span>
+            <h3>QA Workflow Acceleration</h3>
+            <p>Using AI for checklist drafts, edge-case expansion, bug report polishing and automation scenario preparation — with final human validation.</p>
+            <div class="chips compact-chips">
               <span>AI tools</span>
               <span>Test Design</span>
-              <span>Playwright Concepts</span>
+              <span>Bug Reports</span>
               <span>Automation Drafts</span>
             </div>
           </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section contact-section" id="contact">
+      <div class="container contact-card" data-animate>
+        <div>
+          <p class="eyebrow">Contact</p>
+          <h2>Open to QA roles with API and automation focus.</h2>
+          <p>Remote preferred. Hybrid or office roles in Portugal are also relevant.</p>
+        </div>
+        <div class="contact-actions">
+          <a class="button primary" href="https://www.linkedin.com/in/polinapoo/" target="_blank" rel="noreferrer">Message on LinkedIn</a>
+          <a class="button secondary" href="https://github.com/pikuso" target="_blank" rel="noreferrer">View GitHub</a>
         </div>
       </div>
     </section>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,36 @@
+const navToggle = document.querySelector('.nav-toggle');
+const navLinks = document.querySelectorAll('.nav a');
+
+if (navToggle) {
+  navToggle.addEventListener('click', () => {
+    const isOpen = document.body.classList.toggle('nav-open');
+    navToggle.setAttribute('aria-expanded', String(isOpen));
+  });
+}
+
+navLinks.forEach((link) => {
+  link.addEventListener('click', () => {
+    document.body.classList.remove('nav-open');
+    navToggle?.setAttribute('aria-expanded', 'false');
+  });
+});
+
+const animatedItems = document.querySelectorAll('[data-animate]');
+
+if ('IntersectionObserver' in window) {
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('is-visible');
+          observer.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold: 0.18 }
+  );
+
+  animatedItems.forEach((item) => observer.observe(item));
+} else {
+  animatedItems.forEach((item) => item.classList.add('is-visible'));
+}

--- a/styles.css
+++ b/styles.css
@@ -5,24 +5,23 @@
 }
 
 :root {
-  --bg: #050816;
-  --bg-soft: #0b1020;
-  --card: rgba(15, 23, 42, 0.72);
-  --card-strong: rgba(17, 24, 39, 0.9);
-  --text: #f8fafc;
-  --soft: #cbd5e1;
-  --muted: #94a3b8;
-  --line: rgba(255, 255, 255, 0.1);
-  --line-strong: rgba(255, 255, 255, 0.18);
-  --purple: #8b5cf6;
-  --cyan: #22d3ee;
-  --pink: #ec4899;
-  --green: #34d399;
-  --container: 1240px;
-  --radius-xl: 34px;
-  --radius-lg: 24px;
+  --bg: #0b0f14;
+  --bg-soft: #111720;
+  --card: rgba(255, 255, 255, 0.065);
+  --card-strong: rgba(255, 255, 255, 0.095);
+  --text: #f4f1ea;
+  --soft: #d4cec3;
+  --muted: #948d82;
+  --line: rgba(244, 241, 234, 0.12);
+  --line-strong: rgba(244, 241, 234, 0.22);
+  --accent: #9fd8c5;
+  --accent-strong: #c7f4e4;
+  --accent-warm: #d7b98e;
+  --shadow: 0 26px 80px rgba(0, 0, 0, 0.34);
+  --container: 1160px;
+  --radius-xl: 30px;
+  --radius-lg: 22px;
   --radius-md: 16px;
-  --shadow: 0 28px 90px rgba(0, 0, 0, 0.42);
 }
 
 html {
@@ -31,70 +30,40 @@ html {
 
 body {
   min-height: 100vh;
-  font-family:
-    Inter,
-    ui-sans-serif,
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    Arial,
-    sans-serif;
   color: var(--text);
   background:
-    radial-gradient(circle at 14% 8%, rgba(139, 92, 246, 0.24), transparent 30%),
-    radial-gradient(circle at 90% 10%, rgba(34, 211, 238, 0.16), transparent 26%),
-    radial-gradient(circle at 50% 92%, rgba(236, 72, 153, 0.13), transparent 30%),
-    linear-gradient(180deg, #050816 0%, #080d1c 42%, #050816 100%);
+    radial-gradient(circle at 12% 4%, rgba(159, 216, 197, 0.13), transparent 32%),
+    radial-gradient(circle at 86% 10%, rgba(215, 185, 142, 0.10), transparent 26%),
+    linear-gradient(180deg, #0b0f14 0%, #10161e 48%, #0b0f14 100%);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif;
   line-height: 1.6;
   overflow-x: hidden;
 }
 
-.noise {
+body::before {
+  content: "";
   position: fixed;
   inset: 0;
-  z-index: -3;
+  z-index: -1;
   pointer-events: none;
-  opacity: 0.34;
-  background-image:
-    linear-gradient(rgba(255, 255, 255, 0.026) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.026) 1px, transparent 1px);
-  background-size: 54px 54px;
-  mask-image: linear-gradient(to bottom, black 0%, transparent 82%);
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.018) 1px, transparent 1px);
+  background-size: 76px 76px;
+  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.55), transparent 72%);
 }
 
-.orb {
-  position: fixed;
-  z-index: -2;
-  width: 420px;
-  height: 420px;
-  border-radius: 999px;
-  filter: blur(92px);
-  opacity: 0.22;
-  pointer-events: none;
-}
-
-.orb-1 {
-  top: 80px;
-  left: -160px;
-  background: var(--purple);
-}
-
-.orb-2 {
-  right: -150px;
-  top: 220px;
-  background: var(--cyan);
-}
-
-.orb-3 {
-  left: 44%;
-  bottom: -190px;
-  background: var(--pink);
+body.nav-open {
+  overflow: hidden;
 }
 
 a {
   color: inherit;
   text-decoration: none;
+}
+
+img {
+  max-width: 100%;
 }
 
 .container {
@@ -106,86 +75,120 @@ a {
   position: sticky;
   top: 0;
   z-index: 50;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(5, 8, 22, 0.7);
+  border-bottom: 1px solid var(--line);
+  background: rgba(11, 15, 20, 0.76);
   backdrop-filter: blur(20px);
 }
 
 .header-inner {
-  min-height: 74px;
+  min-height: 72px;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 24px;
 }
 
-.logo {
+.brand {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  font-weight: 900;
-  letter-spacing: -0.03em;
+  gap: 11px;
+  font-size: 15px;
+  font-weight: 850;
+  letter-spacing: -0.02em;
 }
 
-.logo-mark {
+.brand-mark {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 34px;
-  height: 34px;
-  border-radius: 12px;
-  color: #020617;
-  background: linear-gradient(135deg, var(--cyan), var(--purple));
-  box-shadow: 0 0 34px rgba(34, 211, 238, 0.22);
+  width: 35px;
+  height: 35px;
+  border: 1px solid var(--line-strong);
+  border-radius: 13px;
+  color: #09110d;
+  background: linear-gradient(135deg, var(--accent-strong), var(--accent-warm));
+  box-shadow: 0 12px 34px rgba(159, 216, 197, 0.16);
 }
 
 .nav {
   display: flex;
   align-items: center;
-  gap: 22px;
-  color: var(--soft);
-  font-size: 14px;
+  gap: 8px;
 }
 
 .nav a {
-  transition: color 0.18s ease;
+  padding: 9px 12px;
+  border-radius: 999px;
+  color: var(--soft);
+  font-size: 14px;
+  font-weight: 720;
+  transition: color 0.18s ease, background 0.18s ease;
 }
 
 .nav a:hover {
   color: var(--text);
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.nav-toggle {
+  display: none;
+  width: 42px;
+  height: 42px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.06);
+  cursor: pointer;
+}
+
+.nav-toggle span {
+  display: block;
+  width: 18px;
+  height: 2px;
+  margin: 5px auto;
+  border-radius: 999px;
+  background: var(--text);
+  transition: transform 0.18s ease, opacity 0.18s ease;
+}
+
+.nav-open .nav-toggle span:first-child {
+  transform: translateY(3.5px) rotate(45deg);
+}
+
+.nav-open .nav-toggle span:last-child {
+  transform: translateY(-3.5px) rotate(-45deg);
 }
 
 .hero {
-  min-height: calc(100vh - 74px);
+  min-height: calc(100vh - 72px);
   display: flex;
   align-items: center;
-  padding: 76px 0 54px;
+  padding: 74px 0 64px;
 }
 
 .hero-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1.08fr) minmax(360px, 0.92fr);
-  gap: 42px;
+  grid-template-columns: minmax(0, 1.08fr) minmax(340px, 0.72fr);
+  gap: 48px;
   align-items: center;
 }
 
 .eyebrow {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
+  gap: 9px;
   margin-bottom: 16px;
-  color: var(--cyan);
+  color: var(--accent);
   font-size: 12px;
-  font-weight: 900;
-  letter-spacing: 0.16em;
+  font-weight: 850;
+  letter-spacing: 0.13em;
   text-transform: uppercase;
 }
 
 .eyebrow::before {
   content: "";
-  width: 28px;
+  width: 26px;
   height: 1px;
-  background: linear-gradient(90deg, var(--cyan), transparent);
+  background: var(--accent);
 }
 
 h1,
@@ -196,194 +199,205 @@ h3 {
 }
 
 h1 {
-  max-width: 860px;
-  font-size: clamp(48px, 7vw, 88px);
-  font-weight: 950;
-}
-
-h1 span {
-  display: block;
-  background: linear-gradient(135deg, #c4b5fd, #67e8f9);
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-}
-
-h2 {
-  font-size: clamp(34px, 4.4vw, 58px);
-  font-weight: 950;
-}
-
-h3 {
-  font-size: 24px;
+  max-width: 740px;
+  font-size: clamp(42px, 7vw, 76px);
   font-weight: 900;
 }
 
-.hero-description {
-  max-width: 780px;
-  margin-top: 26px;
+h2 {
+  font-size: clamp(32px, 4vw, 54px);
+  font-weight: 880;
+}
+
+h3 {
+  font-size: 22px;
+  font-weight: 840;
+}
+
+.hero-text {
+  max-width: 660px;
+  margin-top: 22px;
   color: var(--soft);
   font-size: 18px;
 }
 
-.hero-actions {
+.hero-actions,
+.contact-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 14px;
-  margin-top: 34px;
+  gap: 12px;
+  margin-top: 30px;
 }
 
-.btn {
+.button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 50px;
-  padding: 0 22px;
+  min-height: 48px;
+  padding: 0 18px;
   border-radius: 999px;
   font-size: 14px;
-  font-weight: 900;
-  transition:
-    transform 0.18s ease,
-    box-shadow 0.18s ease,
-    border-color 0.18s ease;
+  font-weight: 820;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
 }
 
-.btn:hover {
+.button:hover {
   transform: translateY(-2px);
 }
 
-.btn-primary {
-  color: #020617;
-  background: linear-gradient(135deg, var(--cyan), #a78bfa);
-  box-shadow: 0 18px 52px rgba(34, 211, 238, 0.18);
+.button.primary {
+  color: #07110d;
+  background: linear-gradient(135deg, var(--accent-strong), var(--accent-warm));
+  box-shadow: 0 18px 50px rgba(159, 216, 197, 0.15);
 }
 
-.btn-secondary {
-  color: var(--text);
+.button.secondary,
+.button.ghost {
   border: 1px solid var(--line-strong);
-  background: rgba(15, 23, 42, 0.58);
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.055);
 }
 
-.btn-secondary:hover {
-  border-color: rgba(34, 211, 238, 0.48);
+.button.ghost {
+  color: var(--soft);
+  background: transparent;
 }
 
-.quick-stack {
+.button.secondary:hover,
+.button.ghost:hover {
+  border-color: rgba(159, 216, 197, 0.44);
+}
+
+.hero-tags,
+.chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
-  margin-top: 28px;
+  gap: 9px;
 }
 
-.quick-stack span,
-.chips span,
-.project-stack span {
+.hero-tags {
+  margin-top: 26px;
+}
+
+.hero-tags span,
+.chips span {
   display: inline-flex;
   align-items: center;
   width: fit-content;
-  min-height: 32px;
-  padding: 7px 12px;
+  min-height: 31px;
+  padding: 6px 11px;
   border: 1px solid var(--line);
   border-radius: 999px;
   color: var(--soft);
-  background: rgba(255, 255, 255, 0.035);
+  background: rgba(255, 255, 255, 0.045);
   font-size: 13px;
   font-weight: 700;
 }
 
-.hero-card {
-  overflow: hidden;
+.profile-card,
+.focus-chart,
+.skill-card,
+.timeline-card,
+.info-stack article,
+.project-card,
+.contact-card {
   border: 1px solid var(--line);
-  border-radius: var(--radius-xl);
-  background:
-    linear-gradient(180deg, rgba(255,255,255,0.08), rgba(255,255,255,0.025)),
-    rgba(15, 23, 42, 0.72);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(180deg, var(--card-strong), var(--card));
   box-shadow: var(--shadow);
-  backdrop-filter: blur(20px);
+  backdrop-filter: blur(18px);
 }
 
-.hero-card-top {
+.profile-card {
+  overflow: hidden;
+  border-radius: var(--radius-xl);
+}
+
+.photo-wrap {
   position: relative;
+  min-height: 350px;
+  background: rgba(255, 255, 255, 0.045);
 }
 
-.hero-card img {
+.photo-wrap img {
   display: block;
   width: 100%;
-  height: 390px;
+  height: 410px;
   object-fit: cover;
   object-position: center;
+  filter: saturate(0.92) contrast(1.02);
 }
 
-.status-card {
+.availability {
   position: absolute;
   left: 18px;
-  right: 18px;
   bottom: 18px;
   display: inline-flex;
   align-items: center;
-  gap: 9px;
-  width: fit-content;
-  max-width: calc(100% - 36px);
-  padding: 10px 13px;
+  gap: 8px;
+  padding: 9px 12px;
   border: 1px solid var(--line);
   border-radius: 999px;
   color: var(--text);
-  background: rgba(2, 6, 23, 0.76);
-  backdrop-filter: blur(14px);
+  background: rgba(11, 15, 20, 0.72);
+  backdrop-filter: blur(12px);
   font-size: 13px;
-  font-weight: 850;
+  font-weight: 800;
 }
 
-.status-dot {
+.availability::before {
+  content: "";
   width: 8px;
   height: 8px;
   border-radius: 999px;
-  background: var(--green);
-  box-shadow: 0 0 16px rgba(52, 211, 153, 0.82);
+  background: var(--accent);
+  box-shadow: 0 0 16px rgba(159, 216, 197, 0.82);
 }
 
-.hero-card-body {
-  padding: 28px;
+.profile-card-body {
+  padding: 26px;
 }
 
-.card-label {
-  margin-bottom: 10px;
-  color: var(--cyan);
+.card-kicker,
+.project-type,
+.timeline-top span,
+.muted {
+  color: var(--muted);
   font-size: 12px;
-  font-weight: 900;
-  letter-spacing: 0.15em;
+  font-weight: 820;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
 }
 
-.hero-card-body h2 {
-  font-size: 31px;
+.profile-card-body h2 {
+  margin-top: 7px;
+  font-size: 28px;
 }
 
-.stats-grid {
+.mini-stats {
   display: grid;
-  gap: 12px;
-  margin-top: 24px;
+  gap: 10px;
+  margin-top: 22px;
 }
 
-.stats-grid div {
-  padding: 15px;
+.mini-stats div {
+  padding: 14px;
   border: 1px solid var(--line);
   border-radius: var(--radius-md);
-  background: rgba(2, 6, 23, 0.34);
+  background: rgba(0, 0, 0, 0.13);
 }
 
-.stats-grid strong,
-.stats-grid span {
+.mini-stats strong,
+.mini-stats span {
   display: block;
 }
 
-.stats-grid strong {
-  color: var(--text);
-  font-size: 16px;
+.mini-stats strong {
+  font-size: 15px;
   line-height: 1.25;
 }
 
-.stats-grid span {
+.mini-stats span {
   margin-top: 4px;
   color: var(--muted);
   font-size: 13px;
@@ -393,373 +407,290 @@ h3 {
   padding: 78px 0;
 }
 
-.section-title {
-  max-width: 820px;
-  margin-bottom: 34px;
+.compact-section {
+  padding-top: 46px;
 }
 
-.row-title {
-  max-width: none;
-  display: flex;
-  align-items: end;
-  justify-content: space-between;
+.split-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 0.95fr) minmax(340px, 0.7fr);
   gap: 28px;
-}
-
-.row-title p {
-  max-width: 430px;
-  color: var(--muted);
-}
-
-.focus-grid {
-  display: grid;
-  grid-template-columns: 1.15fr 0.85fr 0.85fr;
-  gap: 18px;
-}
-
-.focus-card,
-.skill-card,
-.timeline-card,
-.side-card,
-.project-card,
-.contact-box {
-  border: 1px solid var(--line);
-  border-radius: var(--radius-lg);
-  background:
-    linear-gradient(180deg, rgba(255,255,255,0.065), rgba(255,255,255,0.024)),
-    rgba(15, 23, 42, 0.67);
-  box-shadow: 0 20px 66px rgba(0, 0, 0, 0.24);
-  backdrop-filter: blur(18px);
-  transition:
-    transform 0.18s ease,
-    border-color 0.18s ease,
-    background 0.18s ease;
-}
-
-.focus-card:hover,
-.skill-card:hover,
-.timeline-card:hover,
-.side-card:hover,
-.project-card:hover {
-  transform: translateY(-4px);
-  border-color: rgba(34, 211, 238, 0.38);
-}
-
-.focus-card {
-  min-height: 260px;
-  padding: 26px;
-}
-
-.focus-card.large {
-  grid-row: span 2;
-  min-height: 538px;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  background:
-    radial-gradient(circle at 18% 10%, rgba(139, 92, 246, 0.28), transparent 36%),
-    radial-gradient(circle at 90% 5%, rgba(34, 211, 238, 0.13), transparent 30%),
-    linear-gradient(180deg, rgba(255,255,255,0.075), rgba(255,255,255,0.025)),
-    rgba(15, 23, 42, 0.7);
-}
-
-.requirement-visual {
-  display: grid;
-  gap: 12px;
-  margin-bottom: 38px;
-}
-
-.visual-line {
-  width: 100%;
-  height: 1px;
-  margin-bottom: 4px;
-  background: linear-gradient(90deg, var(--cyan), rgba(139, 92, 246, 0.55), transparent);
-}
-
-.visual-row {
-  display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 14px 15px;
-  border: 1px solid var(--line);
-  border-radius: 16px;
-  background: rgba(2, 6, 23, 0.28);
 }
 
-.visual-row span {
-  color: var(--muted);
-  font-size: 13px;
-  font-weight: 750;
-}
-
-.visual-row strong {
-  color: var(--text);
-  font-size: 14px;
-  font-weight: 900;
-}
-
-.focus-card.wide {
-  grid-column: span 2;
-}
-
-.card-number {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 44px;
-  height: 44px;
-  margin-bottom: 24px;
-  border-radius: 15px;
-  color: #020617;
-  background: linear-gradient(135deg, var(--cyan), #a78bfa);
-  font-size: 13px;
-  font-weight: 950;
-}
-
-.focus-card h3,
-.skill-card h3,
-.timeline-card h3,
-.side-card h3,
-.project-card h3 {
-  margin-bottom: 12px;
-}
-
-.focus-card p,
+.section-copy p:not(.eyebrow),
+.contact-card p,
 .timeline-card p,
 .timeline-card li,
-.side-card p,
+.info-stack p,
 .project-card p {
   color: var(--soft);
 }
 
-.skills-layout {
+.section-copy p:not(.eyebrow) {
+  max-width: 650px;
+  margin-top: 18px;
+  font-size: 17px;
+}
+
+.focus-chart {
+  padding: 24px;
+}
+
+.chart-header,
+.bar-row {
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
+  grid-template-columns: 150px 1fr 44px;
+  align-items: center;
+  gap: 14px;
+}
+
+.chart-header {
+  margin-bottom: 22px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.chart-header strong {
+  color: var(--accent);
+  text-align: right;
+}
+
+.bar-row + .bar-row {
+  margin-top: 14px;
+}
+
+.bar-row > span {
+  color: var(--soft);
+  font-size: 13px;
+  font-weight: 760;
+}
+
+.bar-row > strong {
+  color: var(--muted);
+  font-size: 13px;
+  text-align: right;
+}
+
+.bar {
+  overflow: hidden;
+  height: 9px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.bar span {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--accent-warm));
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.9s cubic-bezier(0.19, 1, 0.22, 1);
+}
+
+.is-visible .bar span {
+  transform: scaleX(var(--scale));
+}
+
+.section-head {
+  max-width: 720px;
+  margin-bottom: 30px;
+}
+
+.skills-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 18px;
 }
 
 .skill-card {
-  grid-column: span 3;
   padding: 24px;
 }
 
-.skill-card.highlight {
+.skill-card.accent,
+.project-card.featured {
   background:
-    radial-gradient(circle at 88% 10%, rgba(34, 211, 238, 0.18), transparent 34%),
-    linear-gradient(180deg, rgba(255,255,255,0.075), rgba(255,255,255,0.025)),
-    rgba(15, 23, 42, 0.72);
+    radial-gradient(circle at 90% 12%, rgba(159, 216, 197, 0.16), transparent 34%),
+    linear-gradient(180deg, var(--card-strong), var(--card));
 }
 
-.wide-skill {
-  grid-column: span 6;
+.skill-card.wide {
+  grid-column: 1 / -1;
 }
 
 .chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 9px;
   margin-top: 16px;
 }
 
-.experience-grid {
+.experience-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 330px;
+  grid-template-columns: 0.54fr 1fr 320px;
   gap: 22px;
   align-items: start;
 }
 
-.timeline {
+.timeline,
+.info-stack {
   display: grid;
-  gap: 18px;
+  gap: 16px;
 }
 
 .timeline-card {
-  position: relative;
-  padding: 28px;
-  overflow: hidden;
+  padding: 25px;
 }
 
-.timeline-card::before {
-  content: "";
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: 4px;
-  background: linear-gradient(180deg, var(--cyan), var(--purple));
-}
-
-.timeline-card.compact {
-  min-height: auto;
-}
-
-.timeline-meta {
+.timeline-top {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
-  margin-bottom: 14px;
+  gap: 9px;
+  margin-bottom: 15px;
 }
 
-.timeline-meta span {
+.timeline-top span {
   display: inline-flex;
   padding: 6px 10px;
   border: 1px solid var(--line);
   border-radius: 999px;
-  color: var(--muted);
-  background: rgba(2, 6, 23, 0.28);
-  font-size: 12px;
-  font-weight: 850;
+  background: rgba(0, 0, 0, 0.14);
 }
 
 .role {
-  margin-bottom: 18px;
-  color: var(--cyan) !important;
-  font-weight: 850;
+  margin: 7px 0 16px;
+  color: var(--accent) !important;
+  font-weight: 780;
 }
 
 .timeline-card ul {
   display: grid;
-  gap: 10px;
-  padding-left: 20px;
+  gap: 9px;
+  padding-left: 18px;
 }
 
 .timeline-card li::marker {
-  color: var(--cyan);
+  color: var(--accent);
 }
 
-.side-panel {
+.info-stack {
   position: sticky;
-  top: 98px;
-  display: grid;
-  gap: 18px;
+  top: 96px;
 }
 
-.side-card {
-  padding: 23px;
+.info-stack article {
+  padding: 21px;
 }
 
-.side-date {
-  color: var(--cyan) !important;
-  font-size: 13px;
-  font-weight: 850;
-}
-
-.side-title {
-  margin: 8px 0;
-  color: var(--text) !important;
-  font-weight: 900;
+.info-stack h3 {
+  margin-bottom: 10px;
+  font-size: 20px;
 }
 
 .projects-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 18px;
 }
 
 .project-card {
-  min-height: 330px;
-  padding: 25px;
+  min-height: 300px;
   display: flex;
   flex-direction: column;
+  padding: 24px;
 }
 
-.accent-card {
-  background:
-    radial-gradient(circle at 85% 12%, rgba(139, 92, 246, 0.22), transparent 34%),
-    linear-gradient(180deg, rgba(255,255,255,0.075), rgba(255,255,255,0.025)),
-    rgba(15, 23, 42, 0.72);
-}
-
-.project-top {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 14px;
-  margin-bottom: 24px;
-}
-
-.project-top span {
+.project-type {
   display: inline-flex;
-  min-height: 30px;
-  align-items: center;
-  padding: 6px 11px;
+  width: fit-content;
+  margin-bottom: 18px;
+  padding: 6px 10px;
   border-radius: 999px;
-  color: #020617;
-  background: linear-gradient(135deg, var(--cyan), #a78bfa);
-  font-size: 12px;
-  font-weight: 950;
-}
-
-.project-top strong {
-  color: rgba(248, 250, 252, 0.18);
-  font-size: 42px;
-  line-height: 1;
-  letter-spacing: -0.09em;
+  color: #09110d;
+  background: linear-gradient(135deg, var(--accent-strong), var(--accent-warm));
 }
 
 .project-card p {
-  margin-bottom: 22px;
+  margin: 14px 0 20px;
 }
 
-.project-stack {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+.compact-chips {
   margin-top: auto;
 }
 
 .contact-section {
-  padding-bottom: 48px;
+  padding-bottom: 50px;
 }
 
-.contact-box {
+.contact-card {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 28px;
-  padding: 34px;
+  padding: 30px;
   background:
-    radial-gradient(circle at 10% 20%, rgba(139, 92, 246, 0.28), transparent 32%),
-    radial-gradient(circle at 90% 40%, rgba(34, 211, 238, 0.16), transparent 28%),
-    rgba(15, 23, 42, 0.72);
+    radial-gradient(circle at 8% 22%, rgba(159, 216, 197, 0.16), transparent 28%),
+    linear-gradient(180deg, var(--card-strong), var(--card));
 }
 
-.contact-box p {
-  max-width: 660px;
+.contact-card p:not(.eyebrow) {
+  max-width: 650px;
   margin-top: 14px;
-  color: var(--soft);
 }
 
 .contact-actions {
-  display: flex;
-  flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 12px;
+  margin-top: 0;
 }
 
-@media (max-width: 1100px) {
+[data-animate] {
+  opacity: 0;
+  transform: translateY(18px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+[data-animate].is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+
+  [data-animate] {
+    opacity: 1;
+    transform: none;
+  }
+
+  .bar span {
+    transform: scaleX(var(--scale));
+  }
+}
+
+@media (max-width: 1080px) {
   .hero-grid,
-  .experience-grid {
+  .split-layout,
+  .experience-layout {
     grid-template-columns: 1fr;
   }
 
-  .hero-card {
+  .profile-card {
     max-width: 620px;
   }
 
-  .focus-grid {
-    grid-template-columns: repeat(2, 1fr);
+  .info-stack {
+    position: static;
+    grid-template-columns: repeat(3, 1fr);
   }
-
-  .focus-card.large,
-  .focus-card.wide {
-    grid-row: auto;
-    grid-column: auto;
-    min-height: 260px;
-  }
-
-  .requirement-visual {
-  margin-bottom: 28px;
-}
 
   .projects-grid {
     grid-template-columns: 1fr;
@@ -768,42 +699,59 @@ h3 {
   .project-card {
     min-height: auto;
   }
-
-  .side-panel {
-    position: static;
-    grid-template-columns: repeat(3, 1fr);
-  }
 }
 
-@media (max-width: 860px) {
+@media (max-width: 820px) {
+  .nav-toggle {
+    display: block;
+  }
+
   .nav {
-    display: none;
+    position: fixed;
+    top: 72px;
+    left: 20px;
+    right: 20px;
+    display: grid;
+    gap: 6px;
+    padding: 14px;
+    border: 1px solid var(--line);
+    border-radius: 20px;
+    background: rgba(11, 15, 20, 0.94);
+    box-shadow: var(--shadow);
+    transform: translateY(-12px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.18s ease, transform 0.18s ease;
+  }
+
+  .nav-open .nav {
+    transform: translateY(0);
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .nav a {
+    padding: 12px 13px;
   }
 
   .hero {
     min-height: auto;
-    padding-top: 58px;
+    padding-top: 54px;
   }
 
-  .row-title {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-
-  .skills-layout {
+  .skills-grid {
     grid-template-columns: 1fr;
   }
 
-  .skill-card,
-  .wide-skill {
+  .skill-card.wide {
     grid-column: auto;
   }
 
-  .side-panel {
+  .info-stack {
     grid-template-columns: 1fr;
   }
 
-  .contact-box {
+  .contact-card {
     align-items: flex-start;
     flex-direction: column;
   }
@@ -813,62 +761,44 @@ h3 {
   }
 }
 
-@media (max-width: 680px) {
+@media (max-width: 620px) {
   .container {
-    width: min(100% - 28px, var(--container));
+    width: min(100% - 26px, var(--container));
   }
 
   .section {
     padding: 58px 0;
   }
 
-  .focus-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .hero-description {
-    font-size: 16px;
-  }
-
-  .hero-card img {
-    height: 330px;
-  }
-
-  .hero-card-body,
-  .focus-card,
-  .skill-card,
-  .timeline-card,
-  .side-card,
-  .project-card,
-  .contact-box {
-    padding: 20px;
-  }
-
-  .timeline-meta {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-@media (max-width: 480px) {
-  .container {
-    width: min(100% - 24px, var(--container));
-  }
-
-  .header-inner {
-    min-height: 66px;
-  }
-
   h1 {
-    font-size: 42px;
+    font-size: 40px;
   }
 
   h2 {
-    font-size: 34px;
+    font-size: 32px;
   }
 
-  h3 {
-    font-size: 22px;
+  .hero-text,
+  .section-copy p:not(.eyebrow) {
+    font-size: 16px;
+  }
+
+  .photo-wrap img {
+    height: 330px;
+  }
+
+  .chart-header,
+  .bar-row {
+    grid-template-columns: 1fr 48px;
+  }
+
+  .chart-header span,
+  .bar-row > span {
+    grid-column: 1 / -1;
+  }
+
+  .bar {
+    grid-column: 1 / 2;
   }
 
   .hero-actions,
@@ -876,17 +806,32 @@ h3 {
     width: 100%;
   }
 
-  .btn {
+  .button {
     width: 100%;
   }
 
-  .hero-card img {
+  .profile-card-body,
+  .focus-chart,
+  .skill-card,
+  .timeline-card,
+  .info-stack article,
+  .project-card,
+  .contact-card {
+    padding: 20px;
+  }
+}
+
+@media (max-width: 420px) {
+  .brand span:last-child {
+    display: none;
+  }
+
+  .photo-wrap img {
     height: 300px;
   }
 
-  .quick-stack span,
-  .chips span,
-  .project-stack span {
+  .hero-tags span,
+  .chips span {
     font-size: 12px;
   }
 }


### PR DESCRIPTION
Updated the personal QA portfolio with a cleaner, calmer design and shorter HR-friendly copy.

Changes:
- Reworked the main hero section with concise QA positioning.
- Kept core skills: web, mobile, API testing, automation stack, Jira/Zephyr, DevTools, BrowserStack, Charles Proxy and AI-assisted QA.
- Added a working responsive navigation menu.
- Added a dynamic focus chart and lightweight scroll animations.
- Added a contact CTA focused on QA roles with API and automation direction.
- Removed the noisy/heavy visual style and reduced long text blocks.